### PR TITLE
Schema tests

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Install Dependencies
         run: npm i -f
 
+      - name: Test
+        run: npm run test
+
       - name: Build
         run: npm run build
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "release-major": "release-script major --yes --updateLockfile=no",
     "update-packages": "ncu --upgrade",
     "npm": "npm i -f",
-    "lint": "eslint src"
+    "lint": "eslint src",
+    "test": "ts-node test/testSchema.ts"
   },
   "repository": {
     "type": "git",
@@ -65,6 +66,7 @@
     "@babel/preset-react": "^7.22.15",
     "@types/node": "^20.8.7",
     "@types/react": "^18.2.29",
+    "ajv": "^8.12.0",
     "babel": "^6.23.0",
     "babel-plugin-inline-json-import": "^0.3.2",
     "eslint": "^8.51.0",
@@ -79,6 +81,7 @@
     "gulp-babel": "^8.0.0",
     "gulp-sourcemaps": "^3.0.0",
     "gulp-typescript": "^6.0.0-alpha.1",
+    "ts-node": "^10.9.1",
     "typescript": "^5.2.2"
   }
 }

--- a/schemas/jsonConfig.json
+++ b/schemas/jsonConfig.json
@@ -1431,11 +1431,7 @@
                       "required": [
                         "type"
                       ],
-                      "additionalProperties": false,
                       "allOf": [
-                        {
-                          "$ref": "#/definitions/tableItemBaseProps"
-                        },
                         {
                           "if": {
                             "properties": {
@@ -1446,9 +1442,6 @@
                           },
                           "then": {
                             "allOf": [
-                              {
-                                "$ref": "#/definitions/tableItemBaseProps"
-                              },
                               {
                                 "properties": {
                                   "system": {
@@ -2382,39 +2375,42 @@
                             "allOf": [
                               {
                                 "$ref": "#/definitions/tableItemBaseProps"
-                              },
-                              {
-                                "properties": {
-                                  "label": true,
-                                  "type": true,
-                                  "sm": true,
-                                  "md": true,
-                                  "lg": true,
-                                  "xs": true,
-                                  "newLine": true,
-                                  "hidden": true,
-                                  "hideOnlyControl": true,
-                                  "disabled": true,
-                                  "helpLink": true,
-                                  "help": true,
-                                  "style": true,
-                                  "darkStyle": true,
-                                  "validator": true,
-                                  "validatorNoSaveOnError": true,
-                                  "validatorErrorText": true,
-                                  "noMultiEdit": true,
-                                  "tooltip": true,
-                                  "default": true,
-                                  "defaultFunc": true,
-                                  "onChange": true,
-                                  "noTranslation": true,
-                                  "confirm": true
-                                },
-                                "additionalProperties": false,
-                                "required": [
-                                  "type"
-                                ]
                               }
+                            ],
+                            "properties": {
+                              "attr": true,
+                              "width": true,
+                              "title": true,
+                              "filter": true,
+                              "sort": true,
+                              "label": true,
+                              "type": true,
+                              "sm": true,
+                              "md": true,
+                              "lg": true,
+                              "xs": true,
+                              "newLine": true,
+                              "hidden": true,
+                              "hideOnlyControl": true,
+                              "disabled": true,
+                              "helpLink": true,
+                              "help": true,
+                              "style": true,
+                              "darkStyle": true,
+                              "validator": true,
+                              "validatorNoSaveOnError": true,
+                              "validatorErrorText": true,
+                              "noMultiEdit": true,
+                              "tooltip": true,
+                              "default": true,
+                              "defaultFunc": true,
+                              "onChange": true,
+                              "noTranslation": true,
+                              "confirm": true
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "type"
                             ]
                           }
                         },
@@ -2433,10 +2429,59 @@
                             "allOf": [
                               {
                                 "$ref": "#/definitions/tableItemBaseProps"
-                              },
-                              {
-                                "$ref": "#/definitions/numberProps"
                               }
+                            ],
+                            "properties": {
+                              "attr": true,
+                              "width": true,
+                              "title": true,
+                              "filter": true,
+                              "sort": true,
+                              "placeholder": {
+                                "description": "Placeholder (for text control)",
+                                "type": "string"
+                              },
+                              "min": {
+                                "description": "Minimal value",
+                                "type": "number"
+                              },
+                              "max": {
+                                "description": "Maximum value",
+                                "type": "number"
+                              },
+                              "step": {
+                                "description": "Step size for increase and decrease buttons",
+                                "type": "number"
+                              },
+                              "label": true,
+                              "type": true,
+                              "sm": true,
+                              "md": true,
+                              "lg": true,
+                              "xs": true,
+                              "newLine": true,
+                              "hidden": true,
+                              "hideOnlyControl": true,
+                              "disabled": true,
+                              "helpLink": true,
+                              "help": true,
+                              "style": true,
+                              "darkStyle": true,
+                              "validator": true,
+                              "validatorNoSaveOnError": true,
+                              "validatorErrorText": true,
+                              "noMultiEdit": true,
+                              "tooltip": true,
+                              "default": true,
+                              "defaultFunc": true,
+                              "onChange": true,
+                              "noTranslation": true,
+                              "confirm": true,
+                              "doNotSave": true
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "type"
                             ]
                           }
                         },
@@ -2523,10 +2568,71 @@
                             "allOf": [
                               {
                                 "$ref": "#/definitions/tableItemBaseProps"
-                              },
-                              {
-                                "$ref": "#/definitions/textProps"
                               }
+                            ],
+                            "properties": {
+                              "attr": true,
+                              "width": true,
+                              "title": true,
+                              "filter": true,
+                              "sort": true,
+                              "text": {
+                                "description": "Text input",
+                                "oneOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "$ref": "#/definitions/multilingual"
+                                  }
+                                ]
+                              },
+                              "trim": {
+                                "description": "If text must be trimmed or not (default = true)",
+                                "type": "boolean"
+                              },
+                              "placeholder": {
+                                "description": "Placeholder (for text control)",
+                                "type": "string"
+                              },
+                              "minRows": {
+                                "description": "default is 1. Set this attribute to `2` or more if you want to have a textarea with more than one row",
+                                "type": "number"
+                              },
+                              "maxRows": {
+                                "description": "max rows of textarea. Used only if `minRows` > 1",
+                                "type": "number"
+                              },
+                              "label": true,
+                              "type": true,
+                              "sm": true,
+                              "md": true,
+                              "lg": true,
+                              "xs": true,
+                              "newLine": true,
+                              "hidden": true,
+                              "hideOnlyControl": true,
+                              "disabled": true,
+                              "helpLink": true,
+                              "help": true,
+                              "style": true,
+                              "darkStyle": true,
+                              "validator": true,
+                              "validatorNoSaveOnError": true,
+                              "validatorErrorText": true,
+                              "noMultiEdit": true,
+                              "tooltip": true,
+                              "default": true,
+                              "defaultFunc": true,
+                              "onChange": true,
+                              "noTranslation": true,
+                              "confirm": true,
+                              "maxLength": true,
+                              "doNotSave": true
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "type"
                             ]
                           }
                         },

--- a/schemas/testFailJsonConfig.json
+++ b/schemas/testFailJsonConfig.json
@@ -1,0 +1,411 @@
+{
+  "$schema": "jsonConfig.json",
+  "type": "tabs",
+  "i18n": true,
+  "items": {
+    "mainTab": {
+      "type": "panel",
+      "label": "Main settings",
+      "items": {
+        "bind": {
+          "type": "ip",
+          "listenOnAllPorts": true,
+          "label": "IP",
+          "sm": 12,
+          "md": 8,
+          "lg": 5
+        },
+        "port": {
+          "type": "number",
+          "step": 1,
+          "min": 1,
+          "max": 65565,
+          "label": "Port",
+          "sm": 12,
+          "md": 4,
+          "lg": 3
+        },
+        "secure": {
+          "newLine": true,
+          "type": "checkbox",
+          "label": "Secure(HTTPS)",
+          "sm": 12,
+          "md": 6,
+          "lg": 2
+        },
+        "certPublic": {
+          "type": "certificate",
+          "hidden": "!data.secure",
+          "certType": "public",
+          "validator": "!data.secure || data.certPublic",
+          "label": "Public certificate",
+          "sm": 12,
+          "md": 6,
+          "lg": 2
+        },
+        "certPrivate": {
+          "hidden": "!data.secure",
+          "type": "certificate",
+          "certType": "private",
+          "validator": "!data.secure || data.certPrivate",
+          "label": "Private certificate",
+          "sm": 12,
+          "md": 6,
+          "lg": 2
+        },
+        "certChained": {
+          "hidden": "!data.secure",
+          "type": "certificate",
+          "certType": "chained",
+          "label": "Chained certificate",
+          "sm": 12,
+          "md": 6,
+          "lg": 2
+        },
+        "auth": {
+          "newLine": true,
+          "type": "checkbox",
+          "confirm": {
+            "condition": "!data.secure && data.auth",
+            "title": "Warning!",
+            "text": "Unsecure_Auth",
+            "ok": "Ignore warning",
+            "cancel": "Disable authentication",
+            "type": "warning",
+            "alsoDependsOn": [
+              "secure"
+            ]
+          },
+          "label": "Authentication",
+          "sm": 12,
+          "md": 6,
+          "lg": 2
+        },
+        "defaultUser": {
+          "hidden": "!!data.auth",
+          "type": "user",
+          "label": "Run as",
+          "sm": 12,
+          "md": 6,
+          "lg": 2
+        },
+        "ttl": {
+          "hidden": "!data.auth",
+          "type": "number",
+          "label": "Login timeout",
+          "step": 5,
+          "help": {
+            "en": "sec"
+          },
+          "sm": 12,
+          "md": 6,
+          "lg": 2
+        },
+        "autoUpdate": {
+          "newLine": true,
+          "type": "select",
+          "label": "Auto update",
+          "options": [
+            {
+              "label": "manually",
+              "value": 0
+            },
+            {
+              "label": "every 12 hours",
+              "value": 12
+            },
+            {
+              "label": "every day",
+              "value": 24
+            },
+            {
+              "label": "every 2 days",
+              "value": 48
+            },
+            {
+              "label": "every 3 days",
+              "value": 72
+            },
+            {
+              "label": "every week",
+              "value": 168
+            },
+            {
+              "label": "every 2 weeks",
+              "value": 336
+            },
+            {
+              "label": "monthly",
+              "value": 720
+            }
+          ],
+          "sm": 12,
+          "md": 6,
+          "lg": 2
+        },
+        "thresholdValue": {
+          "type": "number",
+          "min": 50,
+          "label": "Events threshold value",
+          "sm": 12,
+          "md": 4,
+          "lg": 2
+        },
+        "react": {
+          "newLine": true,
+          "type": "checkbox",
+          "label": "Use react UI(experts)",
+          "sm": 12,
+          "md": 6,
+          "lg": 3
+        }
+      }
+    },
+    "leTab": {
+      "type": "panel",
+      "label": "Let's Encrypt SSL",
+      "disabled": "!data.secure",
+      "items": {
+        "_image": {
+          "type": "staticImage",
+          "tooltip": "Read about Let's Encrypt certificates",
+          "href": "https://github.com/ioBroker/ioBroker.admin/blob/master/README.md#lets-encrypt-certificates",
+          "src": "../../img/le.png",
+          "style": {
+            "width": 200,
+            "height": 59
+          }
+        },
+        "_link": {
+          "newLine": true,
+          "type": "staticLink",
+          "href": "https://github.com/ioBroker/ioBroker.admin/blob/master/README.md#lets-encrypt-certificates",
+          "text": "Read about Let's Encrypt certificates",
+          "style": {
+            "fontSize": 16,
+            "marginBottom": 20
+          }
+        },
+        "_linkButton": {
+          "button": true,
+          "variant": "contained",
+          "newLine": true,
+          "type": "staticLink",
+          "href": "https://github.com/ioBroker/ioBroker.admin/blob/master/README.md#lets-encrypt-certificates",
+          "text": "Read about Let's Encrypt certificates",
+          "style": {
+            "fontSize": 16,
+            "marginBottom": 20
+          }
+        },
+        "leEnabled": {
+          "newLine": true,
+          "type": "checkbox",
+          "label": "Use Lets Encrypt certificates"
+        },
+        "leUpdate": {
+          "newLine": true,
+          "type": "checkbox",
+          "hidden": "!data.leEnabled",
+          "label": "Use this instance for automatic update"
+        },
+        "lePort": {
+          "newLine": true,
+          "sm": 11,
+          "lg": 4,
+          "type": "number",
+          "doNotSave": true,
+          "hidden": "!data.leEnabled || !data.leUpdate",
+          "label": "Port to check the domain",
+          "style": {
+            "marginTop": 15,
+            "maxWidth": 200
+          }
+        },
+        "certs": {
+          "type": "certificates",
+          "newLine": true
+        }
+      }
+    },
+    "loginTab": {
+      "type": "panel",
+      "label": "Login background",
+      "disabled": "!data.auth",
+      "items": {
+        "loginBackgroundColor": {
+          "type": "color",
+          "sm": 12,
+          "md": 8,
+          "lg": 4,
+          "label": "Background color of the login screen"
+        },
+        "loginHideLogo": {
+          "newLine": true,
+          "sm": 12,
+          "md": 8,
+          "lg": 4,
+          "type": "checkbox",
+          "label": "Hide logo"
+        },
+        "loginMotto": {
+          "newLine": true,
+          "sm": 12,
+          "md": 8,
+          "lg": 4,
+          "type": "text",
+          "label": "Own motto"
+        },
+        "loginBackgroundImage": {
+          "newLine": true,
+          "sm": 12,
+          "md": 8,
+          "lg": 4,
+          "type": "checkbox",
+          "label": "Use background image"
+        },
+        "login-bg.png": {
+          "newLine": true,
+          "type": "image",
+          "hidden": "!data.loginBackgroundImage",
+          "sm": 12,
+          "md": 8,
+          "lg": 4,
+          "accept": "image/*",
+          "label": "Upload image",
+          "crop": true
+        }
+      }
+    },
+    "instancesTab": {
+      "type": "panel",
+      "label": {
+        "en": "Access to instances"
+      },
+      "items": {
+        "_text1": {
+          "type": "staticText",
+          "text": {
+            "en": "There is a option to allow access to the specific configuration pages of selected instances."
+          }
+        },
+        "accessLimit": {
+          "newLine": true,
+          "type": "checkbox",
+          "label": {
+            "en": "Allow access only to specific instances"
+          }
+        },
+        "applyRights": {
+          "newLine": true,
+          "type": "checkbox",
+          "label": {
+            "en": "Apply access rights for selected instances"
+          }
+        },
+        "accessAllowedConfigs": {
+          "hidden": "!data.accessLimit",
+          "newLine": true,
+          "type": "custom",
+          "url": "custom/customComponents.js",
+          "name": "AdminComponentEasyAccessSet/Components/ConfigCustomEasyAccess",
+          "i18n": true
+        }
+      }
+    },
+    "demoTab": {
+      "type": "panel",
+      "label": {
+        "en": "Demo"
+      },
+      "items": {
+        "demoPattern": {
+          "label": "Pattern",
+          "type": "pattern",
+          "pattern": "my ${data.bind} ${_alive}",
+          "copyToClipboard": true
+        },
+        "_header": {
+          "newLine": true,
+          "type": "divider",
+          "sm": 12
+        },
+        "port": {
+          "type": "port",
+          "min": 1,
+          "max": 65565,
+          "label": "Port",
+          "sm": 12,
+          "md": 4,
+          "lg": 3
+        },
+        "myTable": {
+          "newLine": true,
+          "sm": 12,
+          "noDelete": false,
+          "type": "table",
+          "uniqueColumns": ["ip"],
+          "items": [
+            {
+              "type": "certificates"
+            },
+            {
+              "type": "text",
+              "attr": "ip",
+              "width": 100,
+              "title": "IP",
+              "filter": true,
+              "sort": true
+            },
+            {
+              "type": "number",
+              "attr": "delay",
+              "width": "100%",
+              "title": "Delay",
+              "filter": false,
+              "sort": true,
+              "min": 1,
+              "test": 5
+            },
+            {
+              "type": "checkbox",
+              "attr": "enabled",
+              "width": 50,
+              "title": "Active",
+              "filter": false,
+              "sort": false
+            }
+          ]
+        },
+        "myInstance": {
+          "newLine": true,
+          "sm": 6,
+          "type": "instance",
+          "adapter": "history",
+          "label": "History"
+        },
+        "myObjectId": {
+          "type": "objectId",
+          "sm": 6,
+          "label": "Object ID"
+        },
+        "myLanguage": {
+          "newLine": true,
+          "type": "language",
+          "sm": 6,
+          "label": "Language",
+          "system": true
+        },
+        "_setState": {
+          "type": "setState",
+          "ack": true,
+          "variant": "contained",
+          "okText": "Done",
+          "val": "${data.myLanguage}",
+          "id": "javascript.0.value",
+          "label": "Test"
+        }
+      }
+    }
+  }
+}

--- a/test/testSchema.ts
+++ b/test/testSchema.ts
@@ -2,22 +2,101 @@ import Ajv from "ajv"
 import fs from 'node:fs'
 import path from 'node:path'
 
-const ajv = new Ajv({ allErrors: true, strict: false })
+const ajv = new Ajv({allErrors: true, strict: false})
 const basePath = path.join(__dirname, '..', 'schemas');
 
-const schema = fs.readFileSync(path.join(basePath, 'jsonConfig.json'), { encoding: 'utf-8' });
+const schema = fs.readFileSync(path.join(basePath, 'jsonConfig.json'), {encoding: 'utf-8'});
 
 const validate = ajv.compile(JSON.parse(schema))
 
-for (const fileName of ['testJsonConfig.json', 'testJSONConfigPanel.json']) {
-    const content = fs.readFileSync(path.join(basePath, fileName), { encoding: 'utf-8' });
-    const config = JSON.parse(content);
-    const valid = validate(config);
+/**
+ * Tests which need to be passed
+ */
+function positiveTests(): void {
+    for (const fileName of ['testJsonConfig.json', 'testJSONConfigPanel.json']) {
+        const content = fs.readFileSync(path.join(basePath, fileName), {encoding: 'utf-8'});
+        const config = JSON.parse(content);
+        const valid = validate(config);
 
-    if (!valid) {
-        const errors = validate.errors!.map(entry => JSON.stringify(entry, null, 2))
-        console.error((errors.join('\n')))
-        console.error(`${errors.length} errors occurred on ${fileName}`)
-        process.exit(1)
+        if (!valid) {
+            const errors = validate.errors!.map(entry => JSON.stringify(entry, null, 2))
+            console.error((errors.join('\n')))
+            console.error(`${errors.length} errors occurred on ${fileName}`)
+            process.exit(1)
+        }
     }
 }
+
+/** Expected errors per test */
+const expectedErrorsPerTest = {
+    'testFailJsonConfig.json': [
+        {
+            "instancePath": "/items/demoTab/items/myTable/items/2",
+            "schemaPath": "#/patternProperties/%5E.%2B/allOf/20/then/properties/items/items/allOf/16/then/additionalProperties",
+            "keyword": "additionalProperties",
+            "params": {
+                "additionalProperty": "test"
+            },
+            "message": "must NOT have additional properties"
+        },
+        {
+            "instancePath": "/items/demoTab/items/myTable/items/2",
+            "schemaPath": "#/patternProperties/%5E.%2B/allOf/20/then/properties/items/items/allOf/16/if",
+            "keyword": "if",
+            "params": {
+                "failingKeyword": "then"
+            },
+            "message": "must match \"then\" schema"
+        },
+        {
+            "instancePath": "/items/demoTab/items/myTable",
+            "schemaPath": "#/patternProperties/%5E.%2B/allOf/20/if",
+            "keyword": "if",
+            "params": {
+                "failingKeyword": "then"
+            },
+            "message": "must match \"then\" schema"
+        },
+        {
+            "instancePath": "/items/demoTab",
+            "schemaPath": "#/properties/items/patternProperties/%5E.%2B/allOf/8/if",
+            "keyword": "if",
+            "params": {
+                "failingKeyword": "then"
+            },
+            "message": "must match \"then\" schema"
+        }
+    ]
+} as const;
+
+
+/**
+ * Tests which should be failed
+ */
+function failingTests(): void {
+    for (const fileName of ['testFailJsonConfig.json'] as const) {
+        const content = fs.readFileSync(path.join(basePath, fileName), {encoding: 'utf-8'});
+        const config = JSON.parse(content);
+        const valid = validate(config);
+
+        if (valid) {
+            console.error(`Schema validation was successful at ${fileName}, but a fail was expected`)
+            process.exit(1)
+        }
+
+        const expectedErrors = expectedErrorsPerTest[fileName]
+
+        if (JSON.stringify(expectedErrors) !== JSON.stringify(validate.errors)) {
+            console.error(`Got different errors than expected on file ${fileName}`)
+            console.error(`Expected ${JSON.stringify(expectedErrors)}`)
+            console.error(`Got ${JSON.stringify(validate.errors)}`)
+            process.exit(1)
+        }
+    }
+
+
+}
+
+positiveTests()
+failingTests()
+

--- a/test/testSchema.ts
+++ b/test/testSchema.ts
@@ -1,0 +1,20 @@
+import Ajv from "ajv"
+import fs from 'node:fs'
+import path from 'node:path'
+
+const ajv = new Ajv({ allErrors: true, allowUnionTypes: true, strictTypes: false })
+const basePath = path.join(__dirname, '..', 'schemas');
+
+const schema = fs.readFileSync(path.join(basePath, 'jsonConfig.json'), { encoding: 'utf-8' });
+
+const validate = ajv.compile(JSON.parse(schema))
+
+for (const fileName of ['testJsonConfig.json', 'testJSONConfigPanel.json']) {
+    const content = fs.readFileSync(path.join(basePath, fileName), { encoding: 'utf-8' });
+    const config = JSON.parse(content);
+    const valid = validate(config);
+
+    if (!valid) {
+        throw new Error(JSON.stringify(validate.errors))
+    }
+}

--- a/test/testSchema.ts
+++ b/test/testSchema.ts
@@ -2,7 +2,7 @@ import Ajv from "ajv"
 import fs from 'node:fs'
 import path from 'node:path'
 
-const ajv = new Ajv({ allErrors: true, allowUnionTypes: true, strictTypes: false })
+const ajv = new Ajv({ allErrors: true, strict: false })
 const basePath = path.join(__dirname, '..', 'schemas');
 
 const schema = fs.readFileSync(path.join(basePath, 'jsonConfig.json'), { encoding: 'utf-8' });
@@ -15,6 +15,9 @@ for (const fileName of ['testJsonConfig.json', 'testJSONConfigPanel.json']) {
     const valid = validate(config);
 
     if (!valid) {
-        throw new Error(JSON.stringify(validate.errors))
+        const errors = validate.errors!.map(entry => JSON.stringify(entry, null, 2))
+        console.error((errors.join('\n')))
+        console.error(`${errors.length} errors occurred on ${fileName}`)
+        process.exit(1)
     }
 }


### PR DESCRIPTION
todo: if sticking to draft 7 (which is recommended - see eg https://www.jetbrains.com/help/webstorm/json.html only supporting up to 7) we would need to fix the tables like https://json-schema.org/understanding-json-schema/reference/object#extending which is unfortunately pretty ugly. However, I have not seen another possibility yet.